### PR TITLE
Add modular story engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 EmoQuest is a lightweight, text-based experience exploring emotional and psychological themes. It works entirely in the browser with no external assets and is suitable for GitHub Pages hosting.
 
-Stories are written as JSON files inside the `stories/` folder. Each choice a player makes is tracked locally to provide gentle progress feedback.
+Stories are written as JSON files inside the `stories/` folder. A `stories/list.json` file lists the available modules so the engine can load them automatically. Each choice a player makes is tracked locally to provide gentle progress feedback.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) if you would like to add your own scenarios.

--- a/stories/list.json
+++ b/stories/list.json
@@ -1,0 +1,4 @@
+[
+  "empathy",
+  "example"
+]


### PR DESCRIPTION
## Summary
- automatically load stories listed in `stories/list.json`
- allow selecting a story to play and remember last choice
- keep emotional progress log as before
- mention new list file in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68489d6d220c833185db0754c8d3a9b8