### PR TITLE
Add emotional log tracker with localStorage UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,14 @@
 <body>
   <div id="game"></div>
   <div id="progress" aria-live="polite"></div>
+  <button id="view-log">View My Log</button>
+  <div id="log-modal">
+    <div class="log-content">
+      <h2>Your Emotional Log</h2>
+      <div id="log-body"></div>
+      <button id="close-log">Close</button>
+    </div>
+  </div>
   <script src="tracker.js"></script>
   <script src="insights.js"></script>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,22 @@
 (async function() {
   const gameEl = document.getElementById('game');
   const progressEl = document.getElementById('progress');
+  const logBtn = document.getElementById('view-log');
+  const logModal = document.getElementById('log-modal');
+  const logBody = document.getElementById('log-body');
+  const closeLog = document.getElementById('close-log');
+
+  if (logBtn) {
+    logBtn.addEventListener('click', () => {
+      logBody.innerHTML = Tracker.lines().join('<br>');
+      logModal.style.display = 'flex';
+    });
+  }
+  if (closeLog) {
+    closeLog.addEventListener('click', () => {
+      logModal.style.display = 'none';
+    });
+  }
 
   const storyNames = await fetch('stories/list.json').then(r => r.json());
   const STORIES = {};
@@ -13,6 +29,18 @@
 
   function titleCase(str) {
     return str.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  function notifyNewTags(tags = []) {
+    if (!tags.length) {
+      progressEl.textContent = Tracker.summary();
+      return;
+    }
+    const list = tags.map(t => Tracker.label(t)).join(', ');
+    progressEl.textContent = `You just gained insight into: ${list}`;
+    setTimeout(() => {
+      progressEl.textContent = Tracker.summary();
+    }, 2000);
   }
 
   function render(nodeId) {
@@ -58,7 +86,7 @@
       });
     });
 
-    progressEl.textContent = Tracker.summary();
+    notifyNewTags(node.tags);
   }
 
   function startStory(name) {
@@ -76,7 +104,7 @@
     document.querySelectorAll('[data-story]').forEach(btn => {
       btn.addEventListener('click', () => startStory(btn.getAttribute('data-story')));
     });
-    progressEl.textContent = Tracker.summary();
+    notifyNewTags([]);
   }
 
   const params = new URLSearchParams(location.search);

--- a/style.css
+++ b/style.css
@@ -41,6 +41,40 @@ body {
   text-align: center;
 }
 
+#view-log {
+  margin: 10px 0 20px;
+}
+
+#log-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+#log-modal .log-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 80%;
+  text-align: center;
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+}
+
+#log-modal .log-content h2 {
+  margin-top: 0;
+}
+
+#log-modal button {
+  margin-top: 15px;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/tracker.js
+++ b/tracker.js
@@ -1,4 +1,14 @@
 const Tracker = {
+  EMOJI: {
+    empathy: '💛',
+    anxiety: '🌧',
+    forgiveness: '🌱',
+    boundaries: '🚧',
+    guilt: '🔥',
+    grief: '🖤',
+    acceptance: '🌸',
+    'social anxiety': '💦'
+  },
   load() {
     this.data = JSON.parse(localStorage.getItem('emoquest_tags') || '{}');
   },
@@ -11,11 +21,19 @@ const Tracker = {
     });
     this.save();
   },
+  label(tag) {
+    const emoji = this.EMOJI[tag] || '';
+    const name = tag.replace(/\b\w/g, c => c.toUpperCase());
+    return `${emoji} ${name}`.trim();
+  },
+  lines() {
+    return Object.entries(this.data)
+      .sort((a, b) => b[1] - a[1])
+      .map(([tag, count]) => `${this.label(tag)}: ${count}`);
+  },
   summary() {
-    const entries = Object.entries(this.data);
-    if (!entries.length) return '';
-    const parts = entries.map(([tag, count]) => `${tag} ${count}`);
-    return `You've explored ${parts.join(', ')}.`;
+    const lines = this.lines();
+    return lines.join('  ');
   }
 };
 


### PR DESCRIPTION
## Summary
- track emotion tags with emojis
- show a modal dashboard with a "View My Log" button
- notify players when new tags are gained

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848a118055083319f293ab2c7a6f380