### PR TITLE
Add boundaries, anxiety, resentment stories

### DIFF
--- a/insights.js
+++ b/insights.js
@@ -3,5 +3,13 @@ const INSIGHTS = {
   'social anxiety': 'Discomfort or fear in social situations due to potential judgment.',
   anxiety: 'A feeling of worry or unease about uncertain outcomes.',
   forgiveness: 'Letting go of resentment or anger toward yourself or others.',
-  guilt: 'A sense of regret or responsibility for a past action.'
+  guilt: 'A sense of regret or responsibility for a past action.',
+  boundaries: 'Guidelines we set to protect our time and emotional energy.',
+  resentment: 'Lingering bitterness when we feel wronged or unappreciated.',
+  exhaustion: 'A state of extreme tiredness that can cloud judgment.',
+  support: 'Assistance or comfort offered to someone in need.',
+  relief: 'A feeling of reassurance after distress subsides.',
+  assertion: 'Communicating needs or opinions confidently and respectfully.',
+  communication: 'The exchange of thoughts and information between people.',
+  'self-compassion': 'Treating yourself with kindness during moments of struggle.'
 };

--- a/stories/anxiety.json
+++ b/stories/anxiety.json
@@ -1,0 +1,49 @@
+{
+  "anxiety-1": {
+    "text": "You're about to present in class. Your hands shake and a classmate whispers, 'Are you okay?'",
+    "tags": ["anxiety"],
+    "options": [
+      { "text": "Admit you're nervous", "next": "anxiety-2" },
+      { "text": "Say you're fine", "next": "anxiety-3" },
+      { "text": "Ask them to cover for you", "next": "anxiety-4" }
+    ],
+    "insight": "Naming anxiety is often the first step to softening it.",
+    "reflect": "What would compassion for yourself look like right now?",
+    "start": true
+  },
+  "anxiety-2": {
+    "text": "They nod with understanding and offer to breathe with you before you begin.",
+    "tags": ["anxiety", "support"],
+    "options": [
+      { "text": "Take a deep breath", "next": "anxiety-5" },
+      { "text": "Ask them to present instead", "next": "anxiety-4" }
+    ]
+  },
+  "anxiety-3": {
+    "text": "You force a smile and step up. Your heart races as you start speaking.",
+    "tags": ["anxiety"],
+    "options": [
+      { "text": "Pause and breathe", "next": "anxiety-5" },
+      { "text": "Rush through", "next": "anxiety-6" }
+    ]
+  },
+  "anxiety-4": {
+    "text": "They look surprised but agree. As they speak, you feel a mix of relief and disappointment.",
+    "tags": ["anxiety", "relief"],
+    "options": [
+      { "text": "Thank them and reflect", "next": "anxiety-5" }
+    ]
+  },
+  "anxiety-5": {
+    "text": "You breathe slowly and focus on one line at a time. The room quiets in your mind.",
+    "tags": ["anxiety", "self-compassion"],
+    "options": [],
+    "reflect": "How did acknowledging your fear help you?"
+  },
+  "anxiety-6": {
+    "text": "You rush through the words, barely remembering what you said once it's over.",
+    "tags": ["anxiety"],
+    "options": [],
+    "reflect": "What might happen if you paused instead of pushing ahead?"
+  }
+}

--- a/stories/boundaries.json
+++ b/stories/boundaries.json
@@ -1,0 +1,42 @@
+{
+  "boundaries-1": {
+    "text": "It's 2 AM when a friend messages you again, venting about their partner.",
+    "tags": ["boundaries", "exhaustion"],
+    "options": [
+      { "text": "Reply anyway", "next": "boundaries-2" },
+      { "text": "Set a boundary", "next": "boundaries-3" },
+      { "text": "Mute them for now", "next": "boundaries-4" }
+    ],
+    "insight": "Boundaries protect relationships—they don't destroy them.",
+    "reflect": "Where are you afraid to set boundaries?",
+    "start": true
+  },
+  "boundaries-2": {
+    "text": "You reply despite your fatigue. The conversation drags on and you're even more tired.",
+    "tags": ["exhaustion"],
+    "options": [
+      { "text": "Explain you need sleep", "next": "boundaries-3" },
+      { "text": "Keep talking", "next": "boundaries-5" }
+    ]
+  },
+  "boundaries-3": {
+    "text": "You gently say you're too tired to talk now. They understand, though their messages slow.",
+    "tags": ["boundaries"],
+    "options": [
+      { "text": "Promise to catch up tomorrow", "next": "boundaries-5" }
+    ]
+  },
+  "boundaries-4": {
+    "text": "You mute your phone and try to sleep, wondering if they'll be upset.",
+    "tags": ["boundaries", "anxiety"],
+    "options": [
+      { "text": "Check messages in the morning", "next": "boundaries-5" }
+    ]
+  },
+  "boundaries-5": {
+    "text": "The next day you reconnect rested. They appreciate your honesty about needing space.",
+    "tags": ["boundaries", "empathy"],
+    "options": [],
+    "reflect": "How does rest change the way you support others?"
+  }
+}

--- a/stories/index.json
+++ b/stories/index.json
@@ -1,5 +1,8 @@
 [
   "empathy",
   "example",
-  "guilt"
+  "guilt",
+  "boundaries",
+  "anxiety",
+  "resentment"
 ]

--- a/stories/resentment.json
+++ b/stories/resentment.json
@@ -1,0 +1,42 @@
+{
+  "resentment-1": {
+    "text": "Your group project earns praise, but you did most of the work while others take equal credit.",
+    "tags": ["resentment"],
+    "options": [
+      { "text": "Speak to the teacher", "next": "resentment-2" },
+      { "text": "Talk to your teammate", "next": "resentment-3" },
+      { "text": "Let it go", "next": "resentment-4" }
+    ],
+    "insight": "Unspoken resentment corrodes quiet places in us.",
+    "reflect": "When is it hardest for you to speak up?",
+    "start": true
+  },
+  "resentment-2": {
+    "text": "You consider addressing the imbalance with your teacher after class.",
+    "tags": ["resentment", "assertion"],
+    "options": [
+      { "text": "Explain the work split", "next": "resentment-5" },
+      { "text": "Change your mind", "next": "resentment-4" }
+    ]
+  },
+  "resentment-3": {
+    "text": "You pull your teammate aside. They shrug and say 'We all did our part.'",
+    "tags": ["resentment"],
+    "options": [
+      { "text": "Share how you feel", "next": "resentment-5" },
+      { "text": "Drop the subject", "next": "resentment-4" }
+    ]
+  },
+  "resentment-4": {
+    "text": "You swallow the frustration. It lingers beneath your congratulations.",
+    "tags": ["resentment"],
+    "options": [],
+    "reflect": "What does holding resentment cost you?"
+  },
+  "resentment-5": {
+    "text": "By speaking up, you open a tense but honest conversation about effort.",
+    "tags": ["resentment", "communication"],
+    "options": [],
+    "reflect": "How do you weigh harmony against fairness?"
+  }
+}

--- a/tracker.js
+++ b/tracker.js
@@ -4,10 +4,17 @@ const Tracker = {
     anxiety: '🌧',
     forgiveness: '🌱',
     boundaries: '🚧',
+    resentment: '😠',
     guilt: '🔥',
     grief: '🖤',
     acceptance: '🌸',
-    'social anxiety': '💦'
+    'social anxiety': '💦',
+    exhaustion: '😴',
+    support: '🤝',
+    relief: '😌',
+    assertion: '📢',
+    communication: '💬',
+    'self-compassion': '💗'
   },
   load() {
     this.data = JSON.parse(localStorage.getItem('emoquest_tags') || '{}');


### PR DESCRIPTION
## Summary
- add storylines for `Boundaries`, `Anxiety` and `Resentment`
- register new stories in `index.json`
- expand tag insights and emojis for new themes

## Testing
- `node -e "const fs=require('fs'); const files=fs.readdirSync('stories'); files.filter(f=>f.endsWith('.json')).forEach(f=>JSON.parse(fs.readFileSync('stories/'+f))); console.log('JSON OK');"`


------
https://chatgpt.com/codex/tasks/task_e_6848a6895c2083318371be7833a2a28f