### PR TITLE
Add introspective journey dashboard

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,76 @@
+// Dashboard handling for EmoQuest
+(function() {
+  const dashBtn = document.getElementById('view-journey');
+  const dash = document.getElementById('dashboard');
+  const closeBtn = document.getElementById('close-dashboard');
+  const tagHistory = document.getElementById('tag-history');
+  const unexplored = document.getElementById('unexplored');
+  const summary = document.getElementById('journey-summary');
+
+  if (!dashBtn) return;
+
+  function progressBar(count) {
+    const filled = Math.min(count, 5);
+    const empty = 5 - filled;
+    return '●'.repeat(filled) + '○'.repeat(empty);
+  }
+
+  function update() {
+    Tracker.load();
+    const counts = Tracker.data || {};
+    const tags = Object.keys(Tracker.EMOJI);
+    const lines = tags.map(t => ({
+      tag: t,
+      count: counts[t] || 0,
+      label: Tracker.label(t)
+    }));
+
+    // history
+    const explored = lines.filter(l => l.count > 0)
+      .sort((a,b) => b.count - a.count);
+    tagHistory.innerHTML = explored.length ?
+      explored.map(l => `<div class="tag-line" data-tag="${l.tag}">${l.label} — ${l.count} ${progressBar(l.count)}</div>`).join('') :
+      '<p>No themes explored yet.</p>';
+
+    // unexplored suggestions
+    const missing = lines.filter(l => l.count === 0);
+    unexplored.innerHTML = missing.length ?
+      missing.map(l => `<div>${Tracker.EMOJI[l.tag] || ''} You haven’t explored ${l.tag} yet.</div>`).join('') :
+      '<div>You’ve touched every listed emotion.</div>';
+
+    // reflection summary
+    if (explored.length === 0) {
+      summary.textContent = 'Your journey is just beginning.';
+    } else {
+      const maxTag = explored[0];
+      const lowTag = missing[0] || explored[explored.length - 1];
+      if (explored.length > 1 && maxTag.count - explored[explored.length - 1].count <= 1) {
+        summary.textContent = 'Your explorations are fairly balanced so far.';
+      } else {
+        summary.textContent = `You seem to gravitate toward ${maxTag.label}. Is there space to explore ${Tracker.label(lowTag.tag)}?`;
+      }
+    }
+  }
+
+  dashBtn.addEventListener('click', () => {
+    update();
+    dash.style.display = 'flex';
+  });
+
+  closeBtn.addEventListener('click', () => {
+    dash.style.display = 'none';
+  });
+
+  // tag click jump to story
+  dash.addEventListener('click', e => {
+    const el = e.target.closest('.tag-line');
+    if (el && window.EmoQuest && window.EmoQuest.tagStarts) {
+      const tag = el.getAttribute('data-tag');
+      const start = window.EmoQuest.tagStarts[tag];
+      if (start) {
+        dash.style.display = 'none';
+        window.EmoQuest.render(start);
+      }
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <div id="game"></div>
   <div id="progress" aria-live="polite"></div>
   <button id="view-log">View My Log</button>
+  <button id="view-journey">My Journey</button>
   <div id="log-modal">
     <div class="log-content">
       <h2>Your Emotional Log</h2>
@@ -17,9 +18,20 @@
       <button id="close-log">Close</button>
     </div>
   </div>
+
+  <div id="dashboard">
+    <div class="dashboard-content">
+      <h2>Your Journey</h2>
+      <div id="tag-history"></div>
+      <div id="unexplored"></div>
+      <div id="journey-summary"></div>
+      <button id="close-dashboard">Close</button>
+    </div>
+  </div>
   <button id="reload-stories" style="display:none">Reload Stories</button>
   <script src="tracker.js"></script>
   <script src="insights.js"></script>
+  <script src="dashboard.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -20,15 +20,25 @@
   }
 
   let storyMap = {};
+  let tagStarts = {};
 
   async function loadStories() {
     const files = await fetch('stories/index.json').then(r => r.json());
     const newMap = {};
+    const startMap = {};
     for (const f of files) {
       const data = await fetch(`stories/${f}.json`).then(r => r.json());
+      Object.entries(data).forEach(([id, node]) => {
+        if (node.start && Array.isArray(node.tags)) {
+          node.tags.forEach(tag => {
+            if (!startMap[tag]) startMap[tag] = id;
+          });
+        }
+      });
       Object.assign(newMap, data);
     }
     storyMap = newMap;
+    tagStarts = startMap;
   }
 
   await loadStories();
@@ -113,4 +123,9 @@
   const params = new URLSearchParams(location.search);
   currentNode = params.get('node') || localStorage.getItem('emoquest_current_node') || pickStart();
   render(currentNode);
+
+  window.EmoQuest = {
+    render,
+    tagStarts
+  };
 })();

--- a/style.css
+++ b/style.css
@@ -75,6 +75,33 @@ body {
   margin-top: 15px;
 }
 
+#dashboard {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+#dashboard .dashboard-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 80%;
+  text-align: center;
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+}
+
+#dashboard .tag-line {
+  cursor: pointer;
+  margin: 4px 0;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }


### PR DESCRIPTION
## Summary
- add new **My Journey** button and dashboard modal
- visualize tag history, unexplored themes, and a brief reflection
- expose render function and tag-start mapping to enable tag-based jumps
- style dashboard panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848a7f5ea888331b38752f9a00922e9