### PR TITLE
Add daily emotional prompt mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
   <div id="game"></div>
   <div id="progress" aria-live="polite"></div>
+  <button id="start-prompt">🌞 Start Today’s Prompt</button>
   <button id="view-log">View My Log</button>
   <button id="view-journey">My Journey</button>
   <div id="log-modal">

--- a/stories/anxiety.json
+++ b/stories/anxiety.json
@@ -9,7 +9,8 @@
     ],
     "insight": "Naming anxiety is often the first step to softening it.",
     "reflect": "What would compassion for yourself look like right now?",
-    "start": true
+    "start": true,
+    "promptOfDay": true
   },
   "anxiety-2": {
     "text": "They nod with understanding and offer to breathe with you before you begin.",

--- a/stories/boundaries.json
+++ b/stories/boundaries.json
@@ -9,7 +9,8 @@
     ],
     "insight": "Boundaries protect relationships—they don't destroy them.",
     "reflect": "Where are you afraid to set boundaries?",
-    "start": true
+    "start": true,
+    "promptOfDay": true
   },
   "boundaries-2": {
     "text": "You reply despite your fatigue. The conversation drags on and you're even more tired.",

--- a/stories/empathy.json
+++ b/stories/empathy.json
@@ -2,6 +2,7 @@
   "start": {
     "text": "You see a friend isolate themselves during lunch.",
     "start": true,
+    "promptOfDay": true,
     "tags": ["empathy", "social anxiety"],
     "options": [
       { "text": "Sit silently nearby", "next": "companion" },

--- a/stories/example.json
+++ b/stories/example.json
@@ -2,6 +2,7 @@
   "start": {
     "text": "You find a stranger crying in the park.",
     "start": true,
+    "promptOfDay": true,
     "options": [
       { "text": "Ask if they’re okay", "next": "ask" },
       { "text": "Walk away", "next": "walk" }

--- a/stories/guilt.json
+++ b/stories/guilt.json
@@ -8,7 +8,8 @@
     ],
     "insight": "Guilt is often a signal that you value the relationship.",
     "reflect": "How do you handle your own guilt?",
-    "start": true
+    "start": true,
+    "promptOfDay": true
   },
   "guilt-2": {
     "text": "You send a heartfelt apology. Your friend appreciates your honesty.",

--- a/stories/resentment.json
+++ b/stories/resentment.json
@@ -9,7 +9,8 @@
     ],
     "insight": "Unspoken resentment corrodes quiet places in us.",
     "reflect": "When is it hardest for you to speak up?",
-    "start": true
+    "start": true,
+    "promptOfDay": true
   },
   "resentment-2": {
     "text": "You consider addressing the imbalance with your teacher after class.",

--- a/style.css
+++ b/style.css
@@ -45,6 +45,10 @@ body {
   margin: 10px 0 20px;
 }
 
+#start-prompt {
+  margin: 10px 0;
+}
+
 #log-modal {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- allow starting a daily prompt via **Start Today’s Prompt** button
- select eligible prompt nodes marked with `promptOfDay`
- compute today’s prompt based on the date
- style the new button
- tag starting nodes of existing stories as possible prompts

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6848a92132c08331a7bfbbee7b62607d