### PR TITLE
Implement identity onboarding and personalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <button id="view-log">View My Log</button>
   <button id="view-memory">My Memories</button>
   <button id="view-journey">My Journey</button>
+  <button id="set-identity">Choose Identity</button>
   <div id="log-modal">
     <div class="log-content">
       <h2>Your Emotional Log</h2>
@@ -26,6 +27,20 @@
       <h2>Your Memories</h2>
       <div id="memory-body"></div>
       <button id="close-memory">Close</button>
+    </div>
+  </div>
+
+  <div id="identity-modal">
+    <div class="log-content">
+      <h2>Who are you today?</h2>
+      <p>(Choose the trait that best fits you right now)</p>
+      <div id="identity-options">
+        <button data-identity="empath">💛 The Empath</button>
+        <button data-identity="protector">🔥 The Protector</button>
+        <button data-identity="overthinker">🌧 The Overthinker</button>
+        <button data-identity="quiet">🪨 The Quiet One</button>
+        <button data-identity="chameleon">🎭 The Chameleon</button>
+      </div>
     </div>
   </div>
 

--- a/stories/example.json
+++ b/stories/example.json
@@ -3,10 +3,16 @@
     "text": "You find a stranger crying in the park.",
     "start": true,
     "promptOfDay": true,
+    "identityVariants": {
+      "empath": "You immediately sense their sadness.",
+      "quiet": "You pause, unsure if you should interrupt.",
+      "protector": "You scan the area for whoever caused this."
+    },
     "options": [
       { "text": "Ask if they’re okay", "next": "ask", "remember": "offered-help" },
       { "text": "Walk away", "next": "walk", "remember": "avoided-conflict" },
-      { "text": "Approach them this time", "next": "return", "condition": "avoided-conflict" }
+      { "text": "Approach them this time", "next": "return", "condition": "avoided-conflict" },
+      { "text": "Look for the cause", "next": "search", "identity": ["protector"] }
     ],
     "insight": "Witnessing distress often stirs our desire to help or to retreat.",
     "reflect": "Do you usually approach or avoid people in visible pain?"
@@ -18,13 +24,29 @@
       { "text": "Give advice", "next": "advice" }
     ],
     "insight": "Checking in acknowledges their feelings and opens a path to empathy.",
-    "reflect": "When has a simple question helped you connect with someone?"
+    "reflect": "When has a simple question helped you connect with someone?",
+    "reflectVariants": {
+      "overthinker": "Notice how your mind races for the perfect words.",
+      "empath": "You feel their pain as if it were your own." 
+    }
   },
   "walk": {
     "text": "You leave them to handle their emotions alone.",
     "options": [],
     "insight": "Avoiding a tough moment can stem from discomfort or uncertainty.",
-    "reflect": "Think of a time you stepped away from someone's pain—what held you back?"
+    "reflect": "Think of a time you stepped away from someone's pain—what held you back?",
+    "insightVariants": {
+      "quiet": "Silence can feel safer than stumbling over words.",
+      "chameleon": "You worry how others would see your involvement." 
+    }
+  },
+  "search": {
+    "text": "You scan the park for anyone suspicious but find no obvious threat.",
+    "identity": ["protector"],
+    "options": [
+      { "text": "Return to them", "next": "ask" }
+    ],
+    "insight": "Sometimes protecting means simply being present." 
   },
   "listen": {
     "text": "They appreciate your silent support.",

--- a/style.css
+++ b/style.css
@@ -105,6 +105,32 @@ body {
   margin-top: 15px;
 }
 
+#identity-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+#identity-modal .log-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 80%;
+  text-align: center;
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+}
+
+#identity-modal button {
+  margin: 5px 0;
+}
+
 #dashboard {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- add identity selection modal to the UI
- customize style for identity modal
- support storing and editing identity in script
- render identity-based text, reflection, insight and option gating
- extend example story with identity variants and a special protector branch

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6848b16714d4833189dc39b9def267e3