### PR TITLE
Fix sequential story loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -81,8 +81,12 @@
     const newMap = {};
     const startMap = {};
     const prompts = [];
-    for (const f of files) {
-      const data = await fetch(`stories/${f}.json`).then(r => r.json());
+
+    const storyData = await Promise.all(
+      files.map(f => fetch(`stories/${f}.json`).then(r => r.json()))
+    );
+
+    for (const data of storyData) {
       Object.entries(data).forEach(([id, node]) => {
         if (node.start && Array.isArray(node.tags)) {
           node.tags.forEach(tag => {


### PR DESCRIPTION
## Summary
- fetch story files in parallel

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6848b355ecb08331952020b6d372d103