### PR TITLE
Improve docs, add linting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 EmoQuest contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
 # EmoQuest
 
-EmoQuest is a lightweight, text-based experience exploring emotional and psychological themes. It works entirely in the browser with no external assets and is suitable for GitHub Pages hosting.
+EmoQuest is a lightweight, browser-based story engine exploring emotional themes. Everything runs client side so it works well with static hosting services such as GitHub Pages.
 
-Stories are written as JSON files inside the `stories/` folder. A `stories/index.json` file lists them so the engine can load every file and merge all nodes into one game graph. Each choice a player makes is tracked locally to provide gentle progress feedback. The engine also keeps lightweight "memories" of key decisions so later text can reflect or react to your past actions.
+Stories live inside the `stories/` folder. `stories/index.json` lists every story file to load so the engine can build one combined node graph. Choices a player makes are tracked locally to give gentle progress feedback and short term "memories" that later text can reference.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) if you would like to add your own scenarios.
+
+## Deployment
+
+The project is designed for GitHub Pages. After pushing to the `main` branch simply enable GitHub Pages for the repository and point it at the root of the branch. A `.nojekyll` file is included so assets are served as-is. The site will then be available at `https://<user>.github.io/<repo>/`.
+
+## Creating New Stories
+
+1. Create a JSON file in `stories/` following the node structure described in `CONTRIBUTING.md`.
+2. Add the filename (without extension) to `stories/index.json` so the engine can load it.
+3. Run `npm test` to lint your new story and ensure it parses correctly.
+4. Commit both files and open a pull request.
+
+## Development
+
+Run `npm test` to execute a small linter that validates the story JSON files. This keeps the game data consistent without requiring external dependencies.
+
+During development there is a hidden **Reload Stories** button that allows hot reloading of the story files. It appears automatically when running the site on `localhost`.
+
+## License
+
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/lint.js
+++ b/lint.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+function fail(msg) {
+  console.error(msg);
+  process.exitCode = 1;
+}
+
+function lint() {
+  const indexPath = path.join(__dirname, 'stories', 'index.json');
+  const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+  if (!Array.isArray(index)) {
+    fail('stories/index.json must be an array');
+    return;
+  }
+
+  for (const name of index) {
+    const file = path.join(__dirname, 'stories', `${name}.json`);
+    if (!fs.existsSync(file)) {
+      fail(`Missing story file: ${file}`);
+      continue;
+    }
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch (err) {
+      fail(`Invalid JSON in ${file}: ${err.message}`);
+      continue;
+    }
+    Object.entries(data).forEach(([id, node]) => {
+      if (typeof node.text !== 'string') {
+        fail(`${file} -> ${id} missing 'text'`);
+      }
+      if (!Array.isArray(node.options)) {
+        fail(`${file} -> ${id} missing 'options' array`);
+      } else {
+        node.options.forEach((opt, i) => {
+          if (typeof opt.text !== 'string') {
+            fail(`${file} -> ${id}.options[${i}] missing text`);
+          }
+          if (opt.next && typeof opt.next !== 'string') {
+            fail(`${file} -> ${id}.options[${i}] invalid next`);
+          }
+        });
+      }
+    });
+  }
+}
+
+lint();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "emoquest",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node lint.js"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -256,7 +256,7 @@
     return Object.keys(storyMap)[0];
   }
 
-  if (reloadBtn) {
+  if (reloadBtn && /localhost|127\.0\.0\.1/.test(location.hostname)) {
     reloadBtn.style.display = 'block';
     reloadBtn.addEventListener('click', async () => {
       const ok = await loadStories();


### PR DESCRIPTION
## Summary
- document deployment steps, new-story process, and license info
- add MIT license file
- add Node-based linter and test script
- hide the Reload Stories button unless running locally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848baa93dfc8331b227d156b916703e