### PR TITLE
Fix reflection cleanup on Next button

### DIFF
--- a/script.js
+++ b/script.js
@@ -227,8 +227,7 @@
     if (continueBtn) {
       continueBtn.addEventListener('click', () => {
         continueBtn.remove();
-        const reflectEl = document.querySelector('.reflect');
-        if (reflectEl) reflectEl.remove();
+        document.querySelectorAll('.reflect').forEach(el => el.remove());
         const optDiv = document.querySelector('#game .options');
         if (optDiv) optDiv.style.display = 'block';
       });


### PR DESCRIPTION
## Summary
- ensure all `reflect` elements are removed when the Next button is pressed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848bcb5fb288331aeb3332d9d0b4aad