### PR TITLE
Handle localStorage errors

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -1,11 +1,21 @@
 const Memory = {
   load() {
-    this.flags = JSON.parse(localStorage.getItem('emoquest-memory') || '[]');
-    this.counts = JSON.parse(localStorage.getItem('emoquest-memory-counts') || '{}');
+    try {
+      this.flags = JSON.parse(localStorage.getItem('emoquest-memory') || '[]');
+      this.counts = JSON.parse(localStorage.getItem('emoquest-memory-counts') || '{}');
+    } catch (err) {
+      console.warn('Failed to read localStorage', err);
+      this.flags = [];
+      this.counts = {};
+    }
   },
   save() {
-    localStorage.setItem('emoquest-memory', JSON.stringify(this.flags));
-    localStorage.setItem('emoquest-memory-counts', JSON.stringify(this.counts));
+    try {
+      localStorage.setItem('emoquest-memory', JSON.stringify(this.flags));
+      localStorage.setItem('emoquest-memory-counts', JSON.stringify(this.counts));
+    } catch (err) {
+      console.warn('Failed to write localStorage', err);
+    }
   },
   remember(flag) {
     if (!flag) return;

--- a/script.js
+++ b/script.js
@@ -14,6 +14,23 @@
   const identityModal = document.getElementById('identity-modal');
   const setIdentityBtn = document.getElementById('set-identity');
 
+  function safeGet(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (err) {
+      console.warn('Failed to read localStorage', err);
+      return null;
+    }
+  }
+
+  function safeSet(key, value) {
+    try {
+      localStorage.setItem(key, value);
+    } catch (err) {
+      console.warn('Failed to write localStorage', err);
+    }
+  }
+
   if (logBtn) {
     logBtn.addEventListener('click', () => {
       logBody.innerHTML = Tracker.lines().join('<br>');
@@ -52,7 +69,7 @@
       const btn = e.target.closest('button[data-identity]');
       if (btn) {
         const id = btn.getAttribute('data-identity');
-        localStorage.setItem('emoquest-identity', id);
+        safeSet('emoquest-identity', id);
         identity = id;
         Modal.close(identityModal);
         render(currentNode);
@@ -74,7 +91,7 @@
   let tagStarts = {};
   let promptList = [];
   let todaysPrompt = null;
-  let identity = localStorage.getItem('emoquest-identity');
+  let identity = safeGet('emoquest-identity');
 
   async function loadStories() {
     try {
@@ -148,7 +165,7 @@
     Memory.remember(node.remember);
     Tracker.increment(node.tags);
     currentNode = nodeId;
-    localStorage.setItem('emoquest_current_node', nodeId);
+    safeSet('emoquest_current_node', nodeId);
 
     const optionData = (node.options || [])
       .filter(opt => {
@@ -271,7 +288,7 @@
   }
 
   const params = new URLSearchParams(location.search);
-  currentNode = params.get('node') || localStorage.getItem('emoquest_current_node') || pickStart();
+  currentNode = params.get('node') || safeGet('emoquest_current_node') || pickStart();
   render(currentNode);
 
   if (!identity) {

--- a/tracker.js
+++ b/tracker.js
@@ -17,10 +17,20 @@ const Tracker = {
     'self-compassion': '💗'
   },
   load() {
-    this.data = JSON.parse(localStorage.getItem('emoquest_tags') || '{}');
+    try {
+      const raw = localStorage.getItem('emoquest_tags');
+      this.data = JSON.parse(raw || '{}');
+    } catch (err) {
+      console.warn('Failed to read localStorage', err);
+      this.data = {};
+    }
   },
   save() {
-    localStorage.setItem('emoquest_tags', JSON.stringify(this.data));
+    try {
+      localStorage.setItem('emoquest_tags', JSON.stringify(this.data));
+    } catch (err) {
+      console.warn('Failed to write localStorage', err);
+    }
   },
   increment(tags = []) {
     tags.forEach(tag => {


### PR DESCRIPTION
## Summary
- add safety checks around `localStorage` access in `Tracker`, `Memory`, and main script
- centralize safe read/write helpers in `script.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c34c954c8331919baf9015d02907