### PR TITLE
Enhance modal focus handling and page metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="EmoQuest helps you explore feelings through interactive stories.">
+  <meta name="keywords" content="emotions, journaling, interactive, game">
+  <meta name="author" content="EmoQuest">
   <link rel="stylesheet" href="style.css">
   <title>EmoQuest</title>
 </head>

--- a/modal.js
+++ b/modal.js
@@ -1,6 +1,7 @@
 const Modal = {
   open(modal) {
     if (!modal) return;
+    modal._returnFocus = document.activeElement;
     modal.style.display = 'flex';
     modal.removeAttribute('aria-hidden');
     const focusable = modal.querySelectorAll(
@@ -40,6 +41,11 @@ const Modal = {
       modal.removeEventListener('keydown', modal._modalHandler);
       modal._modalHandler = null;
     }
+    const opener = modal._returnFocus;
+    if (opener && typeof opener.focus === 'function') {
+      opener.focus();
+    }
+    modal._returnFocus = null;
   }
 };
 


### PR DESCRIPTION
## Summary
- return focus to the element that opened a modal when the modal closes
- provide meta description, keywords and author tags for index.html

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c5f9fdf883319df37a0a55d59fdb