### PR TITLE
Add ending mechanics

### DIFF
--- a/script.js
+++ b/script.js
@@ -268,6 +268,41 @@
     let optsDiv = document.createElement('div');
     optsDiv.className = 'options';
 
+    if (node.end) {
+      if (node.closure) {
+        const closeDiv = document.createElement('div');
+        closeDiv.className = 'closure';
+        closeDiv.textContent = node.closure;
+        gameEl.appendChild(closeDiv);
+      }
+      if (node.symbol) {
+        const symbolDiv = document.createElement('div');
+        symbolDiv.className = 'symbol';
+        symbolDiv.textContent = node.symbol;
+        gameEl.appendChild(symbolDiv);
+      }
+      if (node.endInsight) {
+        const endInDiv = document.createElement('div');
+        endInDiv.className = 'insight';
+        endInDiv.textContent = node.endInsight;
+        gameEl.appendChild(endInDiv);
+      }
+      if (node.endReflect) {
+        const endReDiv = document.createElement('div');
+        endReDiv.className = 'reflect';
+        endReDiv.textContent = node.endReflect;
+        gameEl.appendChild(endReDiv);
+      }
+      if (node.journal) {
+        const jBtn = document.createElement('button');
+        jBtn.textContent = 'Journal';
+        jBtn.addEventListener('click', openJournal);
+        gameEl.appendChild(jBtn);
+      }
+      notifyNewTags(node.tags);
+      return;
+    }
+
     if (reflect) {
       const reflectDiv = document.createElement('div');
       reflectDiv.className = 'reflect';

--- a/stories/example.json
+++ b/stories/example.json
@@ -55,12 +55,22 @@
   "listen": {
     "text": "They appreciate your silent support.",
     "tags": ["example"],
-    "options": []
+    "options": [],
+    "end": true,
+    "closure": "The moment settles and you feel a gentle release.",
+    "symbol": "🌱 A small seed of compassion takes root.",
+    "endReflect": "What changed in you during this silence?",
+    "endInsight": "Sometimes presence speaks louder than words."
   },
   "advice": {
     "text": "They thank you for your words.",
     "tags": ["example"],
-    "options": []
+    "options": [],
+    "end": true,
+    "closure": "You shared your perspective and then stepped back.",
+    "symbol": "🪶 A lightness settles as advice is given.",
+    "endReflect": "Did offering guidance ease your concern?",
+    "endInsight": "Advice can comfort, yet listening often does the deepest work."
   },
   "return": {
     "text": "You’ve been here before. This time, you speak up.",

--- a/style.css
+++ b/style.css
@@ -201,3 +201,15 @@ body {
   font-style: italic;
   text-align: center;
 }
+
+.closure {
+  margin: 20px 0;
+  font-weight: bold;
+  text-align: center;
+}
+
+.symbol {
+  margin-bottom: 20px;
+  font-style: italic;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- enable storyline endings with emotional closure, symbolism, and reflections
- style new closing text
- update example story with two concluding nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848ca79dcd48331ba1612fa78b73781