### PR TITLE
Add theme selection menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ EmoQuest is a lightweight, browser-based story engine exploring emotional themes
 
 Stories live inside the `stories/` folder. `stories/index.json` lists every story file to load so the engine can build one combined node graph. Choices a player makes are tracked locally to give gentle progress feedback and short term "memories" that later text can reference.
 
+Use the **Explore Themes** button to browse emotional categories like empathy or guilt and start a scenario that speaks to you.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) if you would like to add your own scenarios.
 
 ## Deployment

--- a/dashboard.js
+++ b/dashboard.js
@@ -74,8 +74,11 @@
       const tag = el.getAttribute('data-tag');
       const start = window.EmoQuest.tagStarts[tag];
       if (start) {
+        const id = Array.isArray(start)
+          ? start[Math.floor(Math.random() * start.length)]
+          : start;
         Modal.close(dash);
-        window.EmoQuest.render(start);
+        window.EmoQuest.render(id);
       }
     }
   });

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <div id="game"></div>
   <div id="progress" aria-live="polite"></div>
   <button id="start-prompt">🌞 Start Today’s Prompt</button>
+  <button id="open-themes">Explore Themes</button>
   <button id="view-log">View My Log</button>
   <button id="view-memory">My Memories</button>
   <button id="view-journal">My Journal</button>
@@ -66,6 +67,14 @@
       <div id="unexplored"></div>
       <div id="journey-summary"></div>
       <button id="close-dashboard">Close</button>
+    </div>
+  </div>
+
+  <div id="theme-modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="log-content">
+      <h2>Explore a Theme</h2>
+      <div id="theme-list"></div>
+      <button id="close-theme">Close</button>
     </div>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -19,6 +19,10 @@
   const closeJournal = document.getElementById('close-journal');
   const identityModal = document.getElementById('identity-modal');
   const setIdentityBtn = document.getElementById('set-identity');
+  const openThemesBtn = document.getElementById('open-themes');
+  const themeModal = document.getElementById('theme-modal');
+  const themeList = document.getElementById('theme-list');
+  const closeTheme = document.getElementById('close-theme');
 
   function safeGet(key) {
     try {
@@ -127,6 +131,42 @@
     });
   }
 
+  function openThemeModal() {
+    if (!themeModal) return;
+    themeList.innerHTML = '';
+    Object.keys(tagStarts).sort().forEach(tag => {
+      const btn = document.createElement('button');
+      btn.setAttribute('data-tag', tag);
+      btn.textContent = Tracker.label(tag);
+      if (INSIGHTS[tag]) btn.title = INSIGHTS[tag];
+      themeList.appendChild(btn);
+    });
+    Modal.open(themeModal);
+  }
+
+  if (openThemesBtn) {
+    openThemesBtn.addEventListener('click', openThemeModal);
+  }
+  if (closeTheme) {
+    closeTheme.addEventListener('click', () => {
+      Modal.close(themeModal);
+    });
+  }
+  if (themeModal) {
+    themeModal.addEventListener('click', e => {
+      const btn = e.target.closest('button[data-tag]');
+      if (btn) {
+        const tag = btn.getAttribute('data-tag');
+        const starts = tagStarts[tag];
+        if (starts && starts.length) {
+          const id = starts[Math.floor(Math.random() * starts.length)];
+          Modal.close(themeModal);
+          render(id);
+        }
+      }
+    });
+  }
+
   if (promptBtn) {
     promptBtn.addEventListener('click', () => {
       if (!todaysPrompt) return;
@@ -164,7 +204,8 @@
         Object.entries(data).forEach(([id, node]) => {
           if (node.start && Array.isArray(node.tags)) {
             node.tags.forEach(tag => {
-              if (!startMap[tag]) startMap[tag] = id;
+              if (!startMap[tag]) startMap[tag] = [];
+              startMap[tag].push(id);
             });
           }
           if (node.promptOfDay) {

--- a/style.css
+++ b/style.css
@@ -105,7 +105,11 @@ body {
   margin-top: 15px;
 }
 
-#journal-modal, #journey-modal {
+#theme-modal button {
+  margin-top: 15px;
+}
+
+#journal-modal, #journey-modal, #theme-modal {
   position: fixed;
   top: 0;
   left: 0;
@@ -117,7 +121,7 @@ body {
   justify-content: center;
 }
 
-#journal-modal .log-content, #journey-modal .log-content {
+#journal-modal .log-content, #journey-modal .log-content, #theme-modal .log-content {
   background: white;
   padding: 20px;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- allow browsing emotional themes with a new Explore Themes button
- open a modal listing all available themes
- start a random scenario from the chosen tag
- support multiple starting nodes per tag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848ceb1b0608331814d62117d3612db