### PR TITLE
Add reflection journal modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,16 @@
     </div>
   </div>
 
+  <div id="reflection-modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="log-content">
+      <h2>Reflection</h2>
+      <p id="reflection-prompt"></p>
+      <textarea id="reflection-entry" placeholder="Write your reflection..."></textarea>
+      <p class="disclaimer">✨ Nothing you write is saved. This is your space alone.</p>
+      <button id="close-reflection">Close</button>
+    </div>
+  </div>
+
   <div id="identity-modal" role="dialog" aria-modal="true" aria-hidden="true">
     <div class="log-content">
       <h2>Who are you today?</h2>
@@ -92,6 +102,7 @@
   <script src="modal.js"></script>
   <script src="dashboard.js"></script>
   <script src="journey.js"></script>
+  <script src="reflection.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/reflection.js
+++ b/reflection.js
@@ -1,0 +1,44 @@
+const Reflection = {
+  PROMPTS: {
+    empathy: ["Recall a moment you offered kindness recently."],
+    anxiety: ["What worries surfaced in this story?"],
+    guilt: ["Is there something you wish to forgive?"],
+    boundaries: ["Where might you draw a gentle line?"],
+    resentment: ["What feeling hides beneath any anger?"],
+    identity: ["Which part of yourself spoke the loudest today?"],
+    default: ["What feeling stands out to you right now?"]
+  },
+  pickPrompt(tags = [], id = '') {
+    for (const t of tags) {
+      if (this.PROMPTS[t]) {
+        const arr = this.PROMPTS[t];
+        return arr[Math.floor(Math.random() * arr.length)];
+      }
+    }
+    if (id && this.PROMPTS[id]) {
+      const arr = this.PROMPTS[id];
+      return arr[Math.floor(Math.random() * arr.length)];
+    }
+    const arr = this.PROMPTS.default;
+    return arr[Math.floor(Math.random() * arr.length)];
+  },
+  init() {
+    this.modal = document.getElementById('reflection-modal');
+    this.entry = document.getElementById('reflection-entry');
+    this.promptEl = document.getElementById('reflection-prompt');
+    this.closeBtn = document.getElementById('close-reflection');
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener('click', () => Modal.close(this.modal));
+    }
+  },
+  open(tags = [], id = '') {
+    if (!this.modal) this.init();
+    if (!this.modal) return;
+    const prompt = this.pickPrompt(tags, id);
+    if (this.promptEl) this.promptEl.textContent = prompt;
+    if (this.entry) this.entry.value = '';
+    Modal.open(this.modal);
+  }
+};
+
+window.Reflection = Reflection;

--- a/script.js
+++ b/script.js
@@ -110,6 +110,12 @@
     });
   }
 
+  function openReflection(tags) {
+    if (window.Reflection && typeof Reflection.open === 'function') {
+      Reflection.open(tags, identity);
+    }
+  }
+
   function showIdentityPrompt() {
     if (identityModal) Modal.open(identityModal);
   }
@@ -340,6 +346,10 @@
         jBtn.addEventListener('click', openJournal);
         gameEl.appendChild(jBtn);
       }
+      const rBtn = document.createElement('button');
+      rBtn.textContent = 'Reflect';
+      rBtn.addEventListener('click', () => openReflection(node.tags));
+      gameEl.appendChild(rBtn);
       notifyNewTags(node.tags);
       return;
     }
@@ -394,6 +404,10 @@
       jBtn.addEventListener('click', openJournal);
       gameEl.appendChild(jBtn);
     }
+    const rBtn = document.createElement('button');
+    rBtn.textContent = 'Reflect';
+    rBtn.addEventListener('click', () => openReflection(node.tags));
+    gameEl.appendChild(rBtn);
 
     notifyNewTags(node.tags);
   }

--- a/style.css
+++ b/style.css
@@ -109,7 +109,7 @@ body {
   margin-top: 15px;
 }
 
-#journal-modal, #journey-modal, #theme-modal {
+#journal-modal, #journey-modal, #theme-modal, #reflection-modal {
   position: fixed;
   top: 0;
   left: 0;
@@ -121,7 +121,7 @@ body {
   justify-content: center;
 }
 
-#journal-modal .log-content, #journey-modal .log-content, #theme-modal .log-content {
+#journal-modal .log-content, #journey-modal .log-content, #theme-modal .log-content, #reflection-modal .log-content {
   background: white;
   padding: 20px;
   border-radius: 8px;
@@ -131,7 +131,7 @@ body {
   box-shadow: 0 0 10px rgba(0,0,0,0.2);
 }
 
-#journal-modal textarea {
+#journal-modal textarea, #reflection-modal textarea {
   width: 100%;
   height: 80px;
   margin-top: 10px;
@@ -216,4 +216,10 @@ body {
   margin-bottom: 20px;
   font-style: italic;
   text-align: center;
+}
+
+.disclaimer {
+  font-size: 0.9em;
+  margin-top: 8px;
+  font-style: italic;
 }


### PR DESCRIPTION
## Summary
- add a new reflection modal to capture thoughts at story endings
- hook up reflection prompts based on tags or identity
- insert a disclaimer that reflections are never saved
- style the modal and disclaimer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d10caba48331bd9353ffb64172d3