### PR TITLE
Add ending session ritual

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <button id="view-journey">My Journey</button>
   <button id="set-identity">Choose Identity</button>
   <button id="open-settings">Settings</button>
+  <button id="end-session">End Session</button>
   <div id="log-modal" role="dialog" aria-modal="true" aria-hidden="true">
     <div class="log-content">
       <h2>Your Emotional Log</h2>
@@ -125,6 +126,15 @@
         <div id="avoid-list"></div>
       </div>
       <button id="close-settings">Close</button>
+    </div>
+  </div>
+
+  <div id="ending-modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="log-content">
+      <h2>Session Reflection</h2>
+      <div id="ending-summary"></div>
+      <div id="ending-message"></div>
+      <button id="close-ending">Close</button>
     </div>
   </div>
   <button id="reload-stories" style="display:none">Reload Stories</button>

--- a/script.js
+++ b/script.js
@@ -29,6 +29,11 @@
   const changeIdBtn = document.getElementById('change-identity');
   const resetIdBtn = document.getElementById('reset-identity');
   const currentIdEl = document.getElementById('current-identity');
+  const endBtn = document.getElementById('end-session');
+  const endingModal = document.getElementById('ending-modal');
+  const endingSummary = document.getElementById('ending-summary');
+  const endingMessage = document.getElementById('ending-message');
+  const closeEnding = document.getElementById('close-ending');
   const themeSelect = document.getElementById('theme-intensity');
   const journalSelect = document.getElementById('journal-pref');
   const avoidListEl = document.getElementById('avoid-list');
@@ -202,6 +207,14 @@
       updateTodaysPrompt();
     });
   }
+  if (endBtn) {
+    endBtn.addEventListener('click', openEnding);
+  }
+  if (closeEnding) {
+    closeEnding.addEventListener('click', () => {
+      Modal.close(endingModal);
+    });
+  }
   if (changeIdBtn) {
     changeIdBtn.addEventListener('click', () => {
       Modal.close(settingsModal);
@@ -237,6 +250,21 @@
     if (journalSelect) journalSelect.value = journalPref;
     if (avoidListEl) populateAvoid();
     Modal.open(settingsModal);
+  }
+
+  function openEnding() {
+    if (!endingModal) return;
+    Tracker.load();
+    const lines = Tracker.lines().slice(0, 3);
+    const tagText = lines.length ?
+      'You explored ' + lines.map(l => l.split(':')[0]).join(', ') + '. ' : '';
+    const idText = identity ? `You walked as the ${identity}. ` : '';
+    if (endingSummary) endingSummary.textContent = tagText + idText;
+    if (endingMessage) {
+      endingMessage.innerHTML =
+        '\u201CIn stillness we find new beginnings.\u201D<br>You can return when you\'re ready.';
+    }
+    Modal.open(endingModal);
   }
 
   function populateAvoid() {

--- a/style.css
+++ b/style.css
@@ -121,7 +121,7 @@ body.deep .log-content {
   margin-top: 15px;
 }
 
-#journal-modal, #journey-modal, #theme-modal, #reflection-modal, #settings-modal {
+#journal-modal, #journey-modal, #theme-modal, #reflection-modal, #settings-modal, #ending-modal {
   position: fixed;
   top: 0;
   left: 0;
@@ -133,7 +133,7 @@ body.deep .log-content {
   justify-content: center;
 }
 
-#journal-modal .log-content, #journey-modal .log-content, #theme-modal .log-content, #reflection-modal .log-content, #settings-modal .log-content {
+#journal-modal .log-content, #journey-modal .log-content, #theme-modal .log-content, #reflection-modal .log-content, #settings-modal .log-content, #ending-modal .log-content {
   background: white;
   padding: 20px;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- add **End Session** button and modal
- style new modal like others
- implement script to display a short summary of explored themes and identity with a closing quote

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d475a7d08331997dc47bdb5f5e9c